### PR TITLE
chore: start service only if carbonio-message-broker is healthy on consul

### DIFF
--- a/videoserver/videoserver-confs/PKGBUILD
+++ b/videoserver/videoserver-confs/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname="carbonio-videoserver-confs-ce"
-pkgver="1.1.12"
-pkgrel="2"
+pkgver="1.1.13"
+pkgrel="1"
 pkgdesc="An open source, general purpose, WebRTC server (configs only)"
 arch=('x86_64')
 maintainer="Zextras <packages@zextras.com"

--- a/videoserver/videoserver/PKGBUILD
+++ b/videoserver/videoserver/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname="carbonio-videoserver-ce"
-pkgver="1.1.12"
-pkgrel="2"
+pkgver="1.1.13"
+pkgrel="1"
 pkgdesc="An open source, general purpose, WebRTC server"
 arch=('x86_64')
 maintainer="Zextras <packages@zextras.com>"
@@ -128,17 +128,19 @@ source=(
   "intentions.json"
   "policies.json"
   "service-protocol.json"
+  "carbonio-message-broker-consul-check"
 )
 sha256sums=('fd91b55294e896370e725f41df4c2780f97b3fd7e030a0574a8340e0da4ae3df'
   '9e24a6a5003bfe58b7d0223e49d2d1ca22f4b5556aecbb62f14e423f63ae2fb6'
   '02138103667e72fe7007a0adcdf053498dd16ddb9ba836c69192c54f9b80a112'
-  'f21207a682102744cd81a96d1d2faa60a856adb83aa87f8ce34ffb43e4934e6e'
+  'dbdc9bfd9b6168c3155de060493034b1b1f3ee5a7591863f27afbe0eb2deb4c3'
   '1fe4e4f4cb2a16c3cddb7cf9d1d6172e373ba2d34b868fff81e10b022ae65c0a'
   'db88dadbaa7ebce1f3c5aa8b6af031096887f6f82c1870b358fd2ca679aa370c'
   '1138cb7d84dac2734176ca68de6c66f0f81b9a8ba943becddd7e9babcc642edc'
   'c30836dda6d88e8e8d2fa66b0372536a2284888aa484fafbeee70c957a29f7e6'
   'cbe699652a2569ac1c5b9d9dd983d8d3788013c346a5c247425e460398771455'
-  '531fc71566b22f3d9ae5662b6cdefe21cd2bc55e73ed01e111e510a6f4d37d6e')
+  '531fc71566b22f3d9ae5662b6cdefe21cd2bc55e73ed01e111e510a6f4d37d6e'
+  '5a6bff6083d723748d0085c073634ba1a664e02fac1da35681b7da28740f84e4')
 
 build() {
   cd "${srcdir}/janus-gateway-1.2.4"
@@ -193,6 +195,8 @@ package() {
     "${pkgdir}/etc/carbonio/videoserver/service-discover/policies.json"
   install -Dm 644 service-protocol.json \
     "${pkgdir}/etc/carbonio/videoserver/service-discover/service-protocol.json"
+  install -Dm 755 carbonio-message-broker-consul-check \
+    "${pkgdir}/usr/bin/carbonio-message-broker-consul-check"
   rm -rf "${pkgdir}"/etc/janus
   rm -rf "${pkgdir}"/opt/zextras/common/share/doc
   rm -rf "${pkgdir}"/opt/zextras/common/share/man

--- a/videoserver/videoserver/carbonio-message-broker-consul-check
+++ b/videoserver/videoserver/carbonio-message-broker-consul-check
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Maximum number of retries
+MAX_RETRIES=3
+# Delay between retries in seconds
+RETRY_DELAY=10
+
+# Query Consul for the health status of 'carbonio-message-broker'
+CONSUL_URL="http://localhost:8500/v1/health/checks/carbonio-message-broker"
+
+# Retry logic
+for ((i=1; i<=MAX_RETRIES; i++)); do
+  # Check if the service is healthy
+  HEALTH_STATUS=$(curl -s $CONSUL_URL | jq -r '.[0].Status')
+
+  if [ "$HEALTH_STATUS" == "passing" ]; then
+    echo "Carbonio message broker is healthy."
+    exit 0
+  fi
+
+  echo "Retry $i/$MAX_RETRIES: Carbonio message broker not healthy, retrying in $RETRY_DELAY seconds..."
+  sleep $RETRY_DELAY
+done
+
+# If we reached here, it means the service is not healthy after retries
+echo "Carbonio message broker is not healthy after $MAX_RETRIES retries."
+exit 1

--- a/videoserver/videoserver/carbonio-videoserver.service
+++ b/videoserver/videoserver/carbonio-videoserver.service
@@ -4,6 +4,7 @@ Wants=network.target
 
 [Service]
 Type=simple
+ExecStartPre=/usr/bin/carbonio-message-broker-consul-check
 ExecStart=/opt/zextras/common/bin/janus
 User=videoserver
 Group=videoserver


### PR DESCRIPTION
* chore: add new script carbonio-message-broker-consul-check

this new script check if carbonio-message-broker is healthy on
consul before starting carbonio-videoserver service.
it will retry for 3 times with a 10s delay for each retry.

* chore: upgrade package version to 1.1.13

ref: WSC-1873