### PR TITLE
chore: carbonio.target should restart the services not covered by zmcontrol

### DIFF
--- a/videoserver/videoserver/PKGBUILD
+++ b/videoserver/videoserver/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-videoserver-ce"
-pkgver="1.1.13"
+pkgver="1.1.14"
 pkgrel="1"
 pkgdesc="An open source, general purpose, WebRTC server"
 arch=('x86_64')
@@ -130,17 +130,19 @@ source=(
   "service-protocol.json"
   "carbonio-message-broker-consul-check"
 )
-sha256sums=('fd91b55294e896370e725f41df4c2780f97b3fd7e030a0574a8340e0da4ae3df'
+sha256sums=(
+  'fd91b55294e896370e725f41df4c2780f97b3fd7e030a0574a8340e0da4ae3df'
   '9e24a6a5003bfe58b7d0223e49d2d1ca22f4b5556aecbb62f14e423f63ae2fb6'
   '02138103667e72fe7007a0adcdf053498dd16ddb9ba836c69192c54f9b80a112'
-  'dbdc9bfd9b6168c3155de060493034b1b1f3ee5a7591863f27afbe0eb2deb4c3'
-  '1fe4e4f4cb2a16c3cddb7cf9d1d6172e373ba2d34b868fff81e10b022ae65c0a'
+  '848e73808ac0d88a9b86ad5ad58eb7279528eea2a04dbce10ae5315b616bf4b4'
+  '43f01db23fe1418a188de45c41800bf3f6f496302f2b9b9f5c0c5153664ca46e'
   'db88dadbaa7ebce1f3c5aa8b6af031096887f6f82c1870b358fd2ca679aa370c'
   '1138cb7d84dac2734176ca68de6c66f0f81b9a8ba943becddd7e9babcc642edc'
   'c30836dda6d88e8e8d2fa66b0372536a2284888aa484fafbeee70c957a29f7e6'
   'cbe699652a2569ac1c5b9d9dd983d8d3788013c346a5c247425e460398771455'
   '531fc71566b22f3d9ae5662b6cdefe21cd2bc55e73ed01e111e510a6f4d37d6e'
-  '5a6bff6083d723748d0085c073634ba1a664e02fac1da35681b7da28740f84e4')
+  '5a6bff6083d723748d0085c073634ba1a664e02fac1da35681b7da28740f84e4'
+)
 
 build() {
   cd "${srcdir}/janus-gateway-1.2.4"

--- a/videoserver/videoserver/carbonio-videoserver-sidecar.service
+++ b/videoserver/videoserver/carbonio-videoserver-sidecar.service
@@ -3,6 +3,7 @@ Description=Carbonio Videoserver sidecar proxy
 Documentation=https://docs.zextras.com/
 Requires=network-online.target
 After=network-online.target
+PartOf=carbonio.target
 
 [Service]
 Type=simple
@@ -20,4 +21,4 @@ TimeoutSec=120
 TimeoutStopSec=120
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=carbonio.target

--- a/videoserver/videoserver/carbonio-videoserver.service
+++ b/videoserver/videoserver/carbonio-videoserver.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Zextras Videoserver
 Wants=network.target
+PartOf=carbonio.target
 
 [Service]
 Type=simple
@@ -14,4 +15,4 @@ TasksMax=infinity
 Nice=-10
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=carbonio.target


### PR DESCRIPTION
Refs: [IN-881](https://zextras.atlassian.net/browse/IN-881)

[IN-881]: https://zextras.atlassian.net/browse/IN-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ