### PR TITLE
fix: remove executable permission on carbonio-videoserver.service

### DIFF
--- a/videoserver/videoserver/PKGBUILD
+++ b/videoserver/videoserver/PKGBUILD
@@ -181,7 +181,7 @@ package() {
   cd "${srcdir}"
   install -Dm 755 carbonio-videoserver \
     "${pkgdir}/usr/bin/carbonio-videoserver"
-  install -Dm 755 carbonio-videoserver.service \
+  install -Dm 644 carbonio-videoserver.service \
     "${pkgdir}/usr/lib/systemd/system/carbonio-videoserver.service"
   install -Dm 644 carbonio-videoserver-sidecar.service \
     "${pkgdir}/lib/systemd/system/carbonio-videoserver-sidecar.service"


### PR DESCRIPTION
ref: CO-2948