### PR TITLE
fix: reset pkgrel to SNAPSHOT placeholder

### DIFF
--- a/videoserver/videoserver-confs/PKGBUILD
+++ b/videoserver/videoserver-confs/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname="carbonio-videoserver-confs-ce"
 pkgver="1.1.19"
-pkgrel="wip.7.381f330f"
+pkgrel="SNAPSHOT"
 pkgdesc="An open source, general purpose, WebRTC server (configs only)"
 arch=('x86_64')
 maintainer="Zextras <packages@zextras.com"

--- a/videoserver/videoserver/PKGBUILD
+++ b/videoserver/videoserver/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname="carbonio-videoserver-ce"
 pkgver="1.1.19"
-pkgrel="wip.7.381f330f"
+pkgrel="SNAPSHOT"
 pkgdesc="An open source, general purpose, WebRTC server"
 arch=('x86_64')
 maintainer="Zextras <packages@zextras.com>"


### PR DESCRIPTION
## Summary
- Reset `pkgrel` in both PKGBUILDs from `wip.7.381f330f` back to `SNAPSHOT`
  - `videoserver/videoserver/PKGBUILD`
  - `videoserver/videoserver-confs/PKGBUILD`
- The dt3_pipeline migration accidentally committed the build-output pkgrel
- This caused the v1.2.0 tag build to produce `carbonio-videoserver-*-1.2.0-wip.7.381f330f` in RC

## Test plan
- [ ] Verify devel build still works (pkgrel overridden by dt3_pipeline sed)
- [ ] After merge, re-trigger tag build to publish clean RC artifact

Generated with Claude Code