### PR TITLE
fix(build): add lib64 to PKG_CONFIG_PATH and LDFLAGS for RHEL8

### DIFF
--- a/videoserver/videoserver-confs/PKGBUILD
+++ b/videoserver/videoserver-confs/PKGBUILD
@@ -1,3 +1,4 @@
+_pkgver="1.4.0"
 pkgname="carbonio-videoserver-confs-ce"
 pkgver="1.1.19"
 pkgrel="SNAPSHOT"
@@ -50,7 +51,7 @@ backup=(
   "etc/janus/janus.eventhandler.rabbitmqevh.jcfg"
 )
 source=(
-  "https://github.com/meetecho/janus-gateway/archive/refs/tags/v1.4.0.tar.gz"
+  "https://github.com/meetecho/janus-gateway/archive/refs/tags/v${_pkgver}.tar.gz"
   "janus.jcfg.patch"
 )
 sha256sums=(
@@ -59,14 +60,16 @@ sha256sums=(
 )
 
 build() {
-  cd "${srcdir}/janus-gateway-1.4.0"
+  cd "${srcdir}/janus-gateway-${_pkgver}"
   patch -Np1 -i ../janus.jcfg.patch
   export CFLAGS="-I/opt/zextras/common/include -ffile-prefix-map=${srcdir}=."
   export LDFLAGS="-Wl,-rpath,/opt/zextras/common/lib \
+    -Wl,-rpath,/opt/zextras/common/lib64 \
     -L/opt/zextras/common/lib \
+    -L/opt/zextras/common/lib64 \
     -L/usr/lib/x86_64-linux-gnu \
     -L/usr/lib"
-  export PKG_CONFIG_PATH="/opt/zextras/common/lib/pkgconfig"
+  export PKG_CONFIG_PATH="/opt/zextras/common/lib/pkgconfig:/opt/zextras/common/lib64/pkgconfig"
 
   ./autogen.sh
   ./configure \
@@ -86,11 +89,12 @@ build() {
     --enable-websockets-event-handler \
     --prefix=/opt/zextras/common \
     --sysconfdir /etc
-  make -j"$(( $(nproc) / 2 ))"
+
+  make
 }
 
 package() {
-  cd "${srcdir}/janus-gateway-1.4.0"
+  cd "${srcdir}/janus-gateway-${_pkgver}"
   make DESTDIR="${pkgdir}" install configs
   rm -rf "${pkgdir}"/opt/
 }

--- a/videoserver/videoserver/PKGBUILD
+++ b/videoserver/videoserver/PKGBUILD
@@ -1,3 +1,4 @@
+_pkgver="1.4.0"
 pkgname="carbonio-videoserver-ce"
 pkgver="1.1.19"
 pkgrel="SNAPSHOT"
@@ -101,7 +102,7 @@ makedepends__yum=(
 section="comm"
 priority="important"
 source=(
-  "https://github.com/meetecho/janus-gateway/archive/refs/tags/v1.4.0.tar.gz"
+  "https://github.com/meetecho/janus-gateway/archive/refs/tags/v${_pkgver}.tar.gz"
   "621-carbonio-videoserver.sh"
   "carbonio-videoserver"
   "carbonio-videoserver.hcl"
@@ -130,7 +131,7 @@ sha256sums=(
 )
 
 _package_common() {
-  cd "${srcdir}/janus-gateway-1.4.0"
+  cd "${srcdir}/janus-gateway-${_pkgver}"
   make DESTDIR="${pkgdir}" install configs
 
   install -Dm755 "${srcdir}/carbonio-videoserver" \
@@ -215,13 +216,15 @@ _postinst_message() {
 }
 
 build() {
-  cd "${srcdir}/janus-gateway-1.4.0"
+  cd "${srcdir}/janus-gateway-${_pkgver}"
   export CFLAGS="-I/opt/zextras/common/include -ffile-prefix-map=${srcdir}=."
   export LDFLAGS="-Wl,-rpath,/opt/zextras/common/lib \
+    -Wl,-rpath,/opt/zextras/common/lib64 \
     -L/opt/zextras/common/lib \
+    -L/opt/zextras/common/lib64 \
     -L/usr/lib/x86_64-linux-gnu \
     -L/usr/lib"
-  export PKG_CONFIG_PATH="/opt/zextras/common/lib/pkgconfig"
+  export PKG_CONFIG_PATH="/opt/zextras/common/lib/pkgconfig:/opt/zextras/common/lib64/pkgconfig"
 
   ./autogen.sh
   ./configure \
@@ -241,7 +244,8 @@ build() {
     --enable-websockets-event-handler \
     --prefix=/opt/zextras/common \
     --sysconfdir /etc
-  make -j"$(($(nproc) / 2))"
+
+  make
 }
 
 package() {


### PR DESCRIPTION
On RHEL8/Rocky8, carbonio packages install .pc files and shared libraries under lib64 instead of lib. Add lib64 paths to both PKG_CONFIG_PATH and LDFLAGS so configure finds libwebsockets and the linker resolves all carbonio .so files correctly.

Refs: CO-3601