### PR TITLE
chore(build): add multi-distro support to local build scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,15 @@ YAP_VERSION       ?= 1.54
 # Prefer podman if installed AND its machine/daemon is reachable; fall back to docker.
 CONTAINER_RUNTIME ?= $(shell if command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then echo podman; elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then echo docker; elif command -v podman >/dev/null 2>&1; then echo podman; else echo docker; fi)
 
+# All supported distribution targets
+ALL_DISTROS = ubuntu-jammy ubuntu-noble rocky-8 rocky-9
+
 # Distribution target
 TARGET ?= ubuntu-jammy
 
 # Path to carbonio-videoserver-thirds artifacts.
 # Defaults to the sibling project's artifacts folder if it exists.
-THIRDS_ARTIFACTS := ../carbonio-videoserver-thirds/artifacts
+THIRDS_ARTIFACTS := ../carbonio-videoserver-thirds/artifacts/$(TARGET)
 THIRDS_DIR ?= $(shell test -d "$(THIRDS_ARTIFACTS)" && echo "$(THIRDS_ARTIFACTS)" || echo none)
 
 # Computed values
@@ -46,12 +49,12 @@ endif
 CONTAINER_OPTS = --rm \
 	--platform linux/amd64 \
 	-v $(CURDIR):/project \
-	-v $(CURDIR)/$(OUTPUT_DIR):/artifacts \
+	-v $(CURDIR)/$(OUTPUT_DIR)/$(TARGET):/artifacts \
 	-v $(CCACHE_DIR):/root/.ccache \
 	-e CCACHE_DIR=/root/.ccache \
 	--entrypoint bash
 
-.PHONY: help build build-macos build-linux pull clean list-targets list-packages
+.PHONY: help build build-all build-macos build-linux pull clean list-targets list-packages
 
 .DEFAULT_GOAL := help
 
@@ -63,49 +66,63 @@ help:
 	@echo "  make <target> [TARGET=<distro>] [THIRDS_DIR=<path>]"
 	@echo ""
 	@echo "Targets:"
-	@echo "  help           Show this help message"
-	@echo "  build          Build using auto-detected host OS (macOS or Linux)"
-	@echo "  build-macos    Build with QEMU workarounds (for macOS / Apple Silicon)"
-	@echo "  build-linux    Build with LTO enabled    (for Linux / CI)"
-	@echo "  pull           Pull the YAP container image"
-	@echo "  clean          Remove build artifacts"
-	@echo "  list-targets   List supported distribution targets"
-	@echo "  list-packages  List all packages defined in yap.json"
+	@echo "  help               Show this help message"
+	@echo "  build              Build for TARGET using auto-detected host OS"
+	@echo "  build-<distro>     Build for a specific distro (e.g. make build-rocky-8)"
+	@echo "  build-all          Build for all distros (use -jN for parallel)"
+	@echo "  build-macos        Build with QEMU workarounds (for macOS / Apple Silicon)"
+	@echo "  build-linux        Build with LTO enabled    (for Linux / CI)"
+	@echo "  pull               Pull the YAP container image for TARGET"
+	@echo "  clean              Remove build artifacts"
+	@echo "  list-targets       List supported distribution targets"
+	@echo "  list-packages      List all packages defined in yap.json"
 	@echo ""
 	@echo "Options:"
 	@echo "  TARGET         Distribution target (default: ubuntu-jammy)"
 	@echo "                 Supported: ubuntu-jammy, ubuntu-noble, rocky-8, rocky-9"
-	@echo "  THIRDS_DIR     Path to carbonio-videoserver-thirds artifacts"
-	@echo "                 (default: ../carbonio-videoserver-thirds/artifacts if it exists)"
+	@echo "  THIRDS_DIR     Path to carbonio-videoserver-thirds artifacts for TARGET"
+	@echo "                 (default: ../carbonio-videoserver-thirds/artifacts/<TARGET> if it exists)"
 	@echo ""
 	@echo "Examples:"
-	@echo "  make build                              # auto-detect host OS, auto-find thirds"
-	@echo "  make build-macos TARGET=ubuntu-jammy"
-	@echo "  make build-linux TARGET=ubuntu-jammy"
-	@echo "  make build THIRDS_DIR=/path/to/thirds/artifacts"
+	@echo "  make build TARGET=rocky-8               # single distro"
+	@echo "  make build-rocky-8                      # shorthand"
+	@echo "  make build-all                          # all distros sequentially"
+	@echo "  make -j4 build-all                      # all distros in parallel"
+	@echo "  make -j2 build-rocky-8 build-rocky-9    # subset in parallel"
 	@echo ""
 
 ## build: Build packages — auto-detects host OS
 build:
 	@echo "==> Detected host OS: $(HOST_OS)"
 	@echo "==> Thirds packages: $(THIRDS_ARG)"
-	@mkdir -p $(OUTPUT_DIR) $(CCACHE_DIR)
+	@mkdir -p $(OUTPUT_DIR)/$(TARGET) $(CCACHE_DIR)
 	$(CONTAINER_RUNTIME) run $(CONTAINER_OPTS) $(THIRDS_MOUNT) $(YAP_IMAGE) \
 		$(BUILD_SCRIPT) $(THIRDS_ARG) $(TARGET)
 
 ## build-macos: Build with QEMU workarounds (macOS / Apple Silicon)
 build-macos:
 	@echo "==> Thirds packages: $(THIRDS_ARG)"
-	@mkdir -p $(OUTPUT_DIR) $(CCACHE_DIR)
+	@mkdir -p $(OUTPUT_DIR)/$(TARGET) $(CCACHE_DIR)
 	$(CONTAINER_RUNTIME) run $(CONTAINER_OPTS) $(THIRDS_MOUNT) $(YAP_IMAGE) \
 		/project/build-macos.sh $(THIRDS_ARG) $(TARGET)
 
 ## build-linux: Build with LTO enabled (Linux / CI)
 build-linux:
 	@echo "==> Thirds packages: $(THIRDS_ARG)"
-	@mkdir -p $(OUTPUT_DIR) $(CCACHE_DIR)
+	@mkdir -p $(OUTPUT_DIR)/$(TARGET) $(CCACHE_DIR)
 	$(CONTAINER_RUNTIME) run $(CONTAINER_OPTS) $(THIRDS_MOUNT) $(YAP_IMAGE) \
 		/project/build-linux.sh $(THIRDS_ARG) $(TARGET)
+
+## build-all: Build packages for all distros — run with -jN for parallel builds
+build-all: $(addprefix build-, $(ALL_DISTROS))
+
+# Generate explicit build-<distro> targets for each distro in ALL_DISTROS.
+define distro-target
+.PHONY: build-$(1)
+build-$(1):
+	$$(MAKE) build TARGET=$(1)
+endef
+$(foreach d,$(ALL_DISTROS),$(eval $(call distro-target,$(d))))
 
 ## pull: Pull the YAP container image for the specified TARGET
 pull:

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -21,20 +21,48 @@ fi
 
 echo "==> Building carbonio-videoserver-ce for $DISTRO"
 
-# Set up base tools and Zextras apt repo
-echo "==> Installing base tools"
-apt-get update -qq
-apt-get install -y -qq gnupg2 ca-certificates
+# Detect package manager family
+if [ -f /etc/debian_version ]; then
+    PKG_FAMILY="debian"
+elif [ -f /etc/redhat-release ]; then
+    PKG_FAMILY="rhel"
+else
+    echo "Error: Unknown Linux distribution in container"
+    exit 1
+fi
 
-echo "==> Setting up public Zextras repository"
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A21
-echo "deb https://repo.zextras.io/release/ubuntu jammy main" > /etc/apt/sources.list.d/zextras.list
-apt-get update -qq
+echo "==> Setting up public Zextras repository (PKG_FAMILY=$PKG_FAMILY)"
+if [ "$PKG_FAMILY" = "debian" ]; then
+    apt-get update -qq
+    apt-get install -y -qq gnupg2 ca-certificates
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A21
+    UBUNTU_CODENAME="${DISTRO#ubuntu-}"
+    echo "deb https://repo.zextras.io/release/ubuntu ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/zextras.list
+    apt-get update -qq
+else
+    dnf install -y -q ca-certificates 2>/dev/null || true
+    case "$DISTRO" in
+        rocky-8) RHEL_REPO="rhel8" ;;
+        rocky-9) RHEL_REPO="rhel9" ;;
+        *) echo "Error: Unknown RHEL distro variant: $DISTRO"; exit 1 ;;
+    esac
+    cat > /etc/yum.repos.d/zextras.repo <<EOF
+[zextras]
+name=Zextras
+baseurl=https://repo.zextras.io/release/${RHEL_REPO}/
+enabled=1
+gpgcheck=0
+EOF
+fi
 
 # Install locally built thirds packages (they override any versions from the repo)
 if [ "$THIRDS_DIR" != "none" ] && [ -n "$THIRDS_DIR" ]; then
     echo "==> Installing thirds packages from $THIRDS_DIR"
-    find "$THIRDS_DIR" -name '*.deb' -exec dpkg -i {} + || apt-get install -f -y
+    if [ "$PKG_FAMILY" = "debian" ]; then
+        find "$THIRDS_DIR" -name '*.deb' -exec dpkg -i {} + || apt-get install -f -y
+    else
+        find "$THIRDS_DIR" -name '*.rpm' -print0 | xargs -0 dnf install -y
+    fi
     echo "==> Thirds packages installed"
 fi
 

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -23,20 +23,52 @@ fi
 
 echo "==> Building carbonio-videoserver-ce for $DISTRO"
 
-# Set up base tools and Zextras apt repo
-echo "==> Installing base tools"
-apt-get update -qq
-apt-get install -y -qq gnupg2 ca-certificates curl
+# Detect package manager family
+if [ -f /etc/debian_version ]; then
+    PKG_FAMILY="debian"
+elif [ -f /etc/redhat-release ]; then
+    PKG_FAMILY="rhel"
+else
+    echo "Error: Unknown Linux distribution in container"
+    exit 1
+fi
 
-echo "==> Setting up public Zextras repository"
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A21
-echo "deb https://repo.zextras.io/release/ubuntu jammy main" > /etc/apt/sources.list.d/zextras.list
-apt-get update -qq
+echo "==> Installing base tools (PKG_FAMILY=$PKG_FAMILY)"
+if [ "$PKG_FAMILY" = "debian" ]; then
+    apt-get update -qq
+    apt-get install -y -qq gnupg2 ca-certificates curl
+
+    echo "==> Setting up public Zextras repository"
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A21
+    UBUNTU_CODENAME="${DISTRO#ubuntu-}"
+    echo "deb https://repo.zextras.io/release/ubuntu ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/zextras.list
+    apt-get update -qq
+else
+    dnf install -y -q curl ca-certificates 2>/dev/null || true
+
+    echo "==> Setting up public Zextras repository"
+    case "$DISTRO" in
+        rocky-8) RHEL_REPO="rhel8" ;;
+        rocky-9) RHEL_REPO="rhel9" ;;
+        *) echo "Error: Unknown RHEL distro variant: $DISTRO"; exit 1 ;;
+    esac
+    cat > /etc/yum.repos.d/zextras.repo <<EOF
+[zextras]
+name=Zextras
+baseurl=https://repo.zextras.io/release/${RHEL_REPO}/
+enabled=1
+gpgcheck=0
+EOF
+fi
 
 # Install locally built thirds packages (they override any versions from the repo)
 if [ "$THIRDS_DIR" != "none" ] && [ -n "$THIRDS_DIR" ]; then
     echo "==> Installing thirds packages from $THIRDS_DIR"
-    find "$THIRDS_DIR" -name '*.deb' -exec dpkg -i {} + || apt-get install -f -y
+    if [ "$PKG_FAMILY" = "debian" ]; then
+        find "$THIRDS_DIR" -name '*.deb' -exec dpkg -i {} + || apt-get install -f -y
+    else
+        find "$THIRDS_DIR" -name '*.rpm' -print0 | xargs -0 dnf install -y
+    fi
     echo "==> Thirds packages installed"
 fi
 


### PR DESCRIPTION
## What
- Add `build-all` and per-distro shorthand targets (`build-<distro>`) to the Makefile
- Separate build output into `artifacts/<TARGET>` subdirectories
- Add RHEL/dnf support in `build-linux.sh` and `build-macos.sh` alongside existing Debian/apt logic