### PR TITLE
fix(deps): add explicit service-discover-base dependency

### DIFF
--- a/videoserver/videoserver/PKGBUILD
+++ b/videoserver/videoserver/PKGBUILD
@@ -29,6 +29,7 @@ depends__apt=(
   "libterm-readline-gnu-perl"
   "pending-setups"
   "service-discover"
+  "service-discover-base"
   "zlib1g"
 )
 depends__ubuntu_noble=(
@@ -54,6 +55,7 @@ depends__ubuntu_noble=(
   "libterm-readline-gnu-perl"
   "pending-setups"
   "service-discover"
+  "service-discover-base"
   "zlib1g"
 )
 depends__yum=(
@@ -73,6 +75,7 @@ depends__yum=(
   "libogg"
   "pending-setups"
   "service-discover"
+  "service-discover-base"
   "zlib"
 )
 makedepends__apt=(


### PR DESCRIPTION
## Summary

Fixes CO-3711: sidecar services fail when `/usr/bin/service-discover-wrapper.sh` is missing.

## Root Cause

`service-discover-wrapper.sh` is provided by `service-discover-base`. This package was only a transitive dependency, so if it became stale or mismatched (e.g. installed from a devel repo with a NEVRA no longer available), `dnf reinstall` could not restore the missing file.

## Fix

Add `service-discover-base` as an explicit dependency so the package manager enforces it at install/upgrade time.

## References

- [CO-3711](https://zextras.atlassian.net/browse/CO-3711)

[CO-3711]: https://zextras.atlassian.net/browse/CO-3711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ