### PR TITLE
fix(docker): pin jammy artifacts when resolving prebuilt debs

### DIFF
--- a/videoserver/docker/Dockerfile
+++ b/videoserver/docker/Dockerfile
@@ -41,9 +41,17 @@ RUN apt-get update \
 
 COPY artifacts/ /tmp/artifacts/
 
+# The codename must be pinned: on default-branch builds the "Upload artifacts"
+# stage unstashes every distro into this same workspace before the docker build,
+# so artifacts/ also holds the noble (and rocky) packages. An unpinned
+# *_${TARGETARCH}.deb glob then matches two files and dpkg -x dies with exit 2.
+# This image is jammy-based, so it must unpack the jammy build.
 RUN set -e; \
-	pkg_ce=$(ls /tmp/artifacts/carbonio-videoserver-ce_*_${TARGETARCH}.deb); \
-	pkg_confs=$(ls /tmp/artifacts/carbonio-videoserver-confs-ce_*_${TARGETARCH}.deb); \
+	pkg_ce=$(ls /tmp/artifacts/carbonio-videoserver-ce_*jammy*_${TARGETARCH}.deb); \
+	pkg_confs=$(ls /tmp/artifacts/carbonio-videoserver-confs-ce_*jammy*_${TARGETARCH}.deb); \
+	for p in "$pkg_ce" "$pkg_confs"; do \
+		[ "$(printf '%s\n' "$p" | wc -l)" -eq 1 ] || { echo "ambiguous deb match: $p" >&2; exit 1; }; \
+	done; \
 	mkdir -p /staging /tmp/debs && cd /tmp/debs && \
 	apt-get download \
 		carbonio-curl:${TARGETARCH} \


### PR DESCRIPTION
The "Publish docker images" stage runs in the same workspace as "Upload artifacts", which unstashes every distro (jammy, noble, rocky-8, rocky-9) before the image build. COPY artifacts/ therefore ships the noble packages too, so carbonio-videoserver-ce_*_${TARGETARCH}.deb matched both the jammy and the noble deb, $pkg_ce/$pkg_confs held two newline-separated paths and dpkg -x aborted with exit 2. On PR builds the upload stage is skipped, so only the jammy stashes were present and the glob happened to be unambiguous — that is why it only broke once the pipeline reached the docker stage on devel.

Pin the codename (the image is FROM ubuntu:jammy, so it must unpack the jammy build) and assert a single match so any future ambiguity fails with a readable message instead of a dpkg error.

Refs: CO-4082, CO-4083