### PR TITLE
fix(ci): update jenkins-lib-common to v4.4.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@v4.4.0',
+    identifier: 'jenkins-lib-common@v4.4.1',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
Update `jenkins-lib-common` library tag from `dt3-migration` to the latest release `v4.4.1`.